### PR TITLE
Fix regex to capture package names with hyphens

### DIFF
--- a/src/xacrodoc/xacrodoc.py
+++ b/src/xacrodoc/xacrodoc.py
@@ -23,7 +23,7 @@ def _xacro_header(name):
 
 def _resolve_package_protocol(text):
     """Resolve file names for meshes specified using `package://`"""
-    pkg_names = re.findall(r"package://(\w+)", text)
+    pkg_names = re.findall(r"package://([\w-]+)", text)
     for pkg in pkg_names:
         abspath = Path(packages.get_path(pkg)).absolute().as_posix()
         text = re.sub(f"package://{pkg}", abspath, text)

--- a/tests/test_xacrodoc.py
+++ b/tests/test_xacrodoc.py
@@ -70,6 +70,32 @@ def test_temp_urdf_file():
     assert text.strip() == expected.strip()
 
 
+def test_resolve_packages():
+    from xacrodoc.xacrodoc import _resolve_package_protocol
+
+    packages.update_package_cache(
+        {
+            "xacrodoc": "..",
+            "example-robot-data": "..",
+            "robot_description": "..",
+        }
+    )
+
+    text = """
+package://xacrodoc/tests/files/threelink.urdf.xacro
+package://example-robot-data/tests/files/threelink.urdf.xacro
+package://robot_description/tests/files/threelink.urdf.xacro
+"""
+    absolute_path = Path("files/threelink.urdf.xacro").absolute().as_posix()
+    expected = f"""
+{absolute_path}
+{absolute_path}
+{absolute_path}
+"""
+    resolved = _resolve_package_protocol(text)
+    assert resolved.strip() == expected.strip()
+
+
 def test_resolve_package_name():
     doc = XacroDoc.from_file("files/mesh.urdf.xacro")
     expected = Path("files/fakemesh.txt").absolute().as_posix()


### PR DESCRIPTION
I was trying to run this package with https://github.com/Gepetto/example-robot-data, the current regex for resolving the packages only returns `example`, this PR fixes it so it return `example-robot-data`
