### PR TITLE
unvendor xacro

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,7 +4,3 @@
 [submodule "tests/packages/Universal_Robots_ROS2_Description"]
 	path = tests/packages/Universal_Robots_ROS2_Description
 	url = https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git
-[submodule "src/xacrodoc/xacro"]
-	path = src/xacrodoc/xacro
-	url = https://github.com/ros/xacro.git
-	branch = ros2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,6 @@ license = { text = "MIT" }
 readme = "README.md"
 requires-python = ">=3.8"
 dependencies = [
-  "pyyaml>=6.0",
   "rospkg>=1.5.0",
   "docutils!=0.21",
   "xacro>=2.1.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
   "pyyaml>=6.0",
   "rospkg>=1.5.0",
   "docutils!=0.21",
+  "xacro>=2.1.1",
 ]
 
 [project.optional-dependencies]

--- a/src/xacrodoc/cli.py
+++ b/src/xacrodoc/cli.py
@@ -3,8 +3,9 @@ import os
 from pathlib import Path
 import sys
 
-from .xacro.xacro.color import error, warning
-from .xacro.xacro import XacroException
+from xacro.color import error, warning
+from xacro import XacroException
+
 from .packages import look_in, update_package_cache, PackageNotFoundError
 from .version import __version__
 from .xacrodoc import XacroDoc

--- a/src/xacrodoc/xacrodoc.py
+++ b/src/xacrodoc/xacrodoc.py
@@ -7,10 +7,11 @@ import tempfile
 from xml.dom.minidom import parseString
 import warnings
 
+import xacro
+from xacro import substitution_args
+from xacro.color import warning
+
 from . import packages
-from .xacro import xacro
-from .xacro.xacro import substitution_args
-from .xacro.xacro.color import warning
 
 
 FILE_PROTOCOL_PREFIX = "file://"

--- a/uv.lock
+++ b/uv.lock
@@ -392,7 +392,7 @@ version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions", version = "4.13.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9' and python_full_version < '3.13'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9' and python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -2120,6 +2120,18 @@ wheels = [
 ]
 
 [[package]]
+name = "xacro"
+version = "2.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/62/b2/12fc318d3563481fe01482dd8e925d38e83b62d64291ed16ab0b6d836a91/xacro-2.1.1.tar.gz", hash = "sha256:3e7adf33cdd90d9fbe8ca0d07d9118acf770a2ad8bf575977019a5c8a60d4d1b", size = 104752, upload-time = "2025-08-28T18:21:20.397Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/6b/3fcfd8589d0e319f5fb56f105acbe791198fd36bb54469a91fbe49d828c4/xacro-2.1.1-py3-none-any.whl", hash = "sha256:c3b330ebd984a3bce6d6482e0047eae5c5333fedd49b30b9b6df863a086b35f7", size = 27087, upload-time = "2025-08-28T18:21:19.165Z" },
+]
+
+[[package]]
 name = "xacrodoc"
 version = "2.0.0"
 source = { editable = "." }
@@ -2129,6 +2141,7 @@ dependencies = [
     { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pyyaml" },
     { name = "rospkg" },
+    { name = "xacro" },
 ]
 
 [package.optional-dependencies]
@@ -2164,6 +2177,7 @@ requires-dist = [
     { name = "mujoco", marker = "extra == 'mujoco'", specifier = ">=3.2.3" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "rospkg", specifier = ">=1.5.0" },
+    { name = "xacro", specifier = ">=2.1.1" },
 ]
 provides-extras = ["mujoco"]
 

--- a/uv.lock
+++ b/uv.lock
@@ -2139,7 +2139,6 @@ dependencies = [
     { name = "docutils", version = "0.20.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
     { name = "docutils", version = "0.21.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9' and python_full_version < '3.11'" },
     { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "pyyaml" },
     { name = "rospkg" },
     { name = "xacro" },
 ]
@@ -2175,7 +2174,6 @@ docs = [
 requires-dist = [
     { name = "docutils", specifier = "!=0.21" },
     { name = "mujoco", marker = "extra == 'mujoco'", specifier = ">=3.2.3" },
-    { name = "pyyaml", specifier = ">=6.0" },
     { name = "rospkg", specifier = ">=1.5.0" },
     { name = "xacro", specifier = ">=2.1.1" },
 ]


### PR DESCRIPTION
Hi,

I did not understand why xacro was added as a git submodule, so I tried to add it as dependency instead to see what would break. 

And it turns out everything seems fine:
```python
uv run pytest
================================================================================================ test session starts ================================================================================================
platform linux -- Python 3.13.1, pytest-9.0.2, pluggy-1.6.0
rootdir: /home/nim/local/adamheins/xacrodoc
configfile: pyproject.toml
testpaths: tests
collected 30 items                                                                                                                                                                                                  

tests/test_cli.py .......                                                                                                                                                                                     [ 23%]
tests/test_extra_packages.py ..                                                                                                                                                                               [ 30%]
tests/test_mjcf.py ....                                                                                                                                                                                       [ 43%]
tests/test_xacrodoc.py .................                                                                                                                                                                      [100%]

================================================================================================ 30 passed in 0.29s =================================================================================================
```

Am I missing anything ?